### PR TITLE
Fix docs.rs build with current rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! A [`tokio_postgres`] TLS connector backed by [`rustls`].
 //!


### PR DESCRIPTION
## Summary
- Remove the deprecated `doc_auto_cfg` feature gate from the crate-level `docsrs` config.
- Keep `doc_cfg` enabled so docs.rs can continue rendering feature-gated items.

## Testing
- Not run (not requested)