### PR TITLE
Expose rustls crypto provider features explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,26 +10,32 @@ keywords = ["tokio-postgres", "rustls", "postgres", "sql"]
 categories = ["database"]
 
 [features]
-default = []
+default = ["aws-lc-rs", "logging", "prefer-post-quantum", "tls12"]
+aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 channel-binding = ["dep:sha2", "dep:x509-parser"]
+fips = ["aws-lc-rs", "rustls/fips", "tokio-rustls/fips"]
+logging = ["rustls/logging", "tokio-rustls/logging"]
 native-roots = ["dep:rustls-native-certs"]
+prefer-post-quantum = ["aws-lc-rs", "rustls/prefer-post-quantum"]
+ring = ["rustls/ring", "tokio-rustls/ring"]
+tls12 = ["rustls/tls12", "tokio-rustls/tls12"]
 webpki-roots = ["dep:webpki-roots"]
 
 [dependencies]
-rustls = { version = "0.23" }
+rustls = { version = "0.23", default-features = false, features = ["std"] }
 rustls-native-certs = { version = "0.8", optional = true }
 rustls-pki-types = { version = "1.12" }
 sha2 = { version = "0.11", optional = true }
 tokio = { version = "1.47" }
 tokio-postgres = { version = "0.7" }
-tokio-rustls = { version = "0.26" }
+tokio-rustls = { version = "0.26", default-features = false }
 webpki-roots = { version = "1.0", optional = true }
 x509-parser = { version = "0.18", optional = true }
 
 [dev-dependencies]
 rcgen = { version = "0.14" }
 tokio = { version = "1.47", features = ["io-util", "macros", "net", "rt-multi-thread"] }
-tokio-rustls = { version = "0.26" }
+tokio-rustls = { version = "0.26", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -29,8 +29,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Features
 
+- **aws-lc-rs**: enables rustls' AWS-LC-RS crypto provider. Enabled by default.
 - **channel-binding**: enables TLS channel binding, if supported.
+- **fips**: enables rustls' AWS-LC-RS FIPS provider support.
+- **logging**: enables rustls logging. Enabled by default.
 - **native-roots**: enables a function for creating a `rustls::ClientConfig` using the rustls-native-certs crate.
+- **prefer-post-quantum**: enables rustls' post-quantum-preferred AWS-LC-RS key exchange ordering. Enabled by default.
+- **ring**: enables rustls' ring crypto provider. Use `default-features = false` if you want ring without AWS-LC-RS.
+- **tls12**: enables rustls TLS 1.2 support. Enabled by default.
 - **webpki-roots**: enables a function for creating a `rustls::ClientConfig` using the webpki-roots crate.
 
 ## License

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,6 +209,8 @@ mod tests {
 
     #[test]
     fn config_native_roots_succeeds_when_at_least_one_root_is_added() {
+        install_test_crypto_provider();
+
         let valid_cert = self_signed_cert_der();
         let invalid_cert = CertificateDer::from(vec![0]);
 
@@ -222,4 +224,19 @@ mod tests {
 
         CertificateDer::from(cert.der().to_vec())
     }
+
+    #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
+    fn install_test_crypto_provider() {
+        use std::sync::Once;
+
+        static INSTALL_PROVIDER: Once = Once::new();
+        INSTALL_PROVIDER.call_once(|| {
+            rustls::crypto::aws_lc_rs::default_provider()
+                .install_default()
+                .expect("failed to install rustls crypto provider for tests");
+        });
+    }
+
+    #[cfg(not(all(feature = "aws-lc-rs", feature = "ring")))]
+    fn install_test_crypto_provider() {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,14 @@
 //!
 //! # Features
 //!
+//! - **aws-lc-rs**: enables rustls' AWS-LC-RS crypto provider. Enabled by default.
 //! - **channel-binding**: enables TLS channel binding, if supported.
+//! - **fips**: enables rustls' AWS-LC-RS FIPS provider support.
+//! - **logging**: enables rustls logging. Enabled by default.
 //! - **native-roots**: enables a helper function for creating a [`rustls::ClientConfig`] using the native roots of your OS.
+//! - **prefer-post-quantum**: enables rustls' post-quantum-preferred AWS-LC-RS key exchange ordering. Enabled by default.
+//! - **ring**: enables rustls' ring crypto provider. Use `default-features = false` if you want ring without AWS-LC-RS.
+//! - **tls12**: enables rustls TLS 1.2 support. Enabled by default.
 //! - **webpki-roots**: enables a helper function for creating a [`rustls::ClientConfig`] using the webpki roots.
 
 use std::{io, sync::Arc};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,8 +1,8 @@
 use std::io;
 use std::sync::Arc;
 
+use rustls_tokio_postgres::MakeRustlsConnect;
 use rustls_tokio_postgres::rustls::ClientConfig;
-use rustls_tokio_postgres::{MakeRustlsConnect, config_no_verify};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
@@ -14,6 +14,8 @@ use tokio_postgres::tls::{MakeTlsConnect, TlsConnect};
 /// Generate a self-signed certificate for `localhost` and return
 /// (server_config, client_config).
 fn test_tls_configs() -> (rustls::ServerConfig, ClientConfig) {
+    install_test_crypto_provider();
+
     let key_pair = rcgen::KeyPair::generate().unwrap();
     let cert_params = rcgen::CertificateParams::new(vec!["localhost".into()]).unwrap();
     let cert = cert_params.self_signed(&key_pair).unwrap();
@@ -34,6 +36,26 @@ fn test_tls_configs() -> (rustls::ServerConfig, ClientConfig) {
 
     (server_config, client_config)
 }
+
+fn config_no_verify() -> ClientConfig {
+    install_test_crypto_provider();
+    rustls_tokio_postgres::config_no_verify()
+}
+
+#[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
+fn install_test_crypto_provider() {
+    use std::sync::Once;
+
+    static INSTALL_PROVIDER: Once = Once::new();
+    INSTALL_PROVIDER.call_once(|| {
+        rustls_tokio_postgres::rustls::crypto::aws_lc_rs::default_provider()
+            .install_default()
+            .expect("failed to install rustls crypto provider for tests");
+    });
+}
+
+#[cfg(not(all(feature = "aws-lc-rs", feature = "ring")))]
+fn install_test_crypto_provider() {}
 
 /// Spin up a TLS echo server on a random port. Returns the local address.
 async fn start_echo_server(server_config: rustls::ServerConfig) -> std::net::SocketAddr {


### PR DESCRIPTION
## Summary
- Disable inherited default features on `rustls` and `tokio-rustls`
- Add explicit crate features for `aws-lc-rs`, `ring`, `fips`, `logging`, `tls12`, and `prefer-post-quantum`
- Keep the crate default aligned with the current AWS-LC-RS-based behavior
- Update README and crate docs to document the new feature surface

## Testing
- `cargo check --offline`
- `cargo check --offline --no-default-features`
- `cargo check --offline --no-default-features --features ring`
- `cargo check --offline --no-default-features --features fips`
- `cargo check --offline --all-features`
- `cargo test --offline`
- `cargo fmt --check`
- `cargo doc --offline --all-features --no-deps`