### PR TITLE
Tighten dependency hygiene and use rustls pki types re-export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ webpki-roots = ["dep:webpki-roots"]
 [dependencies]
 rustls = { version = "0.23", default-features = false, features = ["std"] }
 rustls-native-certs = { version = "0.8", optional = true }
-rustls-pki-types = { version = "1.12" }
 sha2 = { version = "0.11", optional = true }
 tokio = { version = "1.47" }
 tokio-postgres = { version = "0.7" }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -5,8 +5,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use rustls::ClientConfig;
-use rustls_pki_types::ServerName;
+use rustls::{ClientConfig, pki_types::ServerName};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_postgres::tls::{ChannelBinding, TlsConnect};
 use tokio_rustls::{TlsConnector, client::TlsStream as RustlsTlsStream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,8 +40,10 @@
 
 use std::{io, sync::Arc};
 
-use rustls::ClientConfig;
-use rustls_pki_types::{InvalidDnsNameError, ServerName};
+use rustls::{
+    ClientConfig,
+    pki_types::{InvalidDnsNameError, ServerName},
+};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_postgres::tls::MakeTlsConnect;
 


### PR DESCRIPTION
## Summary
- Removed the direct `rustls-pki-types` dependency and switched code to `rustls::pki_types` re-exports.
- Refreshed the ignored `Cargo.lock` so dependency resolution tracks current allowed releases.
- Kept the change scoped to import cleanup and manifest hygiene.

## Testing
- `cargo fmt --check`
- `cargo test`
- `cargo test --all-features`
- `cargo clippy --all-features -- -D warnings`