### PR TITLE
Bump crate version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-tokio-postgres"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 authors = ["Ryan Fowler"]
 description = "TLS implementation for tokio-postgres using rustls"


### PR DESCRIPTION
## Summary
- Increment the crate version from `0.2.0` to `0.3.0`
- Prepare the release branch for publishing to crates.io

## Testing
- Not run (not requested)