### PR TITLE
Use rustls-platform-verifier for platform trust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 channel-binding = ["dep:sha2", "dep:x509-parser"]
 fips = ["aws-lc-rs", "rustls/fips", "tokio-rustls/fips"]
 logging = ["rustls/logging", "tokio-rustls/logging"]
-native-roots = ["dep:rustls-native-certs"]
+native-roots = ["platform-verifier"]
+platform-verifier = ["dep:rustls-platform-verifier"]
 prefer-post-quantum = ["aws-lc-rs", "rustls/prefer-post-quantum"]
 ring = ["rustls/ring", "tokio-rustls/ring"]
 tls12 = ["rustls/tls12", "tokio-rustls/tls12"]
@@ -23,7 +24,7 @@ webpki-roots = ["dep:webpki-roots"]
 
 [dependencies]
 rustls = { version = "0.23", default-features = false, features = ["std"] }
-rustls-native-certs = { version = "0.8", optional = true }
+rustls-platform-verifier = { version = "0.7", optional = true }
 sha2 = { version = "0.11", optional = true }
 tokio = { version = "1.47" }
 tokio-postgres = { version = "0.7" }

--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@ A [`tokio_postgres`](https://crates.io/crates/tokio-postgres) TLS connector back
 ## Usage
 
 Prefer a verifying TLS configuration for normal application code. This crate
-provides helpers for the OS-native trust store and the Mozilla WebPKI trust
-store behind optional features.
+provides helpers for the platform verifier and the Mozilla WebPKI trust store
+behind optional features.
 
-### Native roots
+### Platform verifier
 
-Enable the `native-roots` feature to use the operating system's native
-certificate store.
+Enable the `platform-verifier` feature to use certificate verification provided
+by the current platform.
 
 ```rust
-use rustls_tokio_postgres::{config_native_roots, MakeRustlsConnect};
+use rustls_tokio_postgres::{config_platform_verifier, MakeRustlsConnect};
 use tokio_postgres::connect;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     static CONFIG: &str = "host=localhost user=postgres";
 
-    let tls = MakeRustlsConnect::new(config_native_roots()?);
+    let tls = MakeRustlsConnect::new(config_platform_verifier()?);
 
     let (_client, _conn) = connect(CONFIG, tls).await?;
 
@@ -63,7 +63,7 @@ man-in-the-middle attacks possible.
 
 Use this only for local development, tests, or tightly controlled environments
 where server identity is verified by another trusted mechanism. Prefer
-`config_native_roots()`, `config_webpki_roots()`, or a custom
+`config_platform_verifier()`, `config_webpki_roots()`, or a custom
 `rustls::ClientConfig` with an explicit root store for production systems.
 
 ```rust
@@ -88,7 +88,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **channel-binding**: enables TLS channel binding, if supported.
 - **fips**: enables rustls' AWS-LC-RS FIPS provider support.
 - **logging**: enables rustls logging. Enabled by default.
-- **native-roots**: enables a function for creating a `rustls::ClientConfig` using the rustls-native-certs crate.
+- **native-roots**: deprecated alias for **platform-verifier**.
+- **platform-verifier**: enables a function for creating a `rustls::ClientConfig` using the platform certificate verifier.
 - **prefer-post-quantum**: enables rustls' post-quantum-preferred AWS-LC-RS key exchange ordering. Enabled by default.
 - **ring**: enables rustls' ring crypto provider. Use `default-features = false` if you want ring without AWS-LC-RS.
 - **tls12**: enables rustls TLS 1.2 support. Enabled by default.

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,98 +5,53 @@ use rustls::{
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
 };
 
-/// An error that may be returned when loading native root certificates.
+/// An error returned by the deprecated `config_native_roots` helper.
 #[cfg(feature = "native-roots")]
 #[derive(Debug)]
-pub struct NativeRootsError(NativeRootsErrorKind);
-
-#[cfg(feature = "native-roots")]
-#[derive(Debug)]
-enum NativeRootsErrorKind {
-    Load(Vec<rustls_native_certs::Error>),
-    NoUsableRootsLoaded,
-}
-
-#[cfg(feature = "native-roots")]
-impl NativeRootsError {
-    fn load(errors: Vec<rustls_native_certs::Error>) -> Self {
-        Self(NativeRootsErrorKind::Load(errors))
-    }
-
-    fn no_usable_roots_loaded() -> Self {
-        Self(NativeRootsErrorKind::NoUsableRootsLoaded)
-    }
-}
+pub struct NativeRootsError(TlsError);
 
 #[cfg(feature = "native-roots")]
 impl std::fmt::Display for NativeRootsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.0 {
-            NativeRootsErrorKind::Load(errors) => {
-                write!(f, "failed to load native root certificates")?;
-                if errors.is_empty() {
-                    return Ok(());
-                }
-
-                write!(f, ": ")?;
-                for (i, err) in errors.iter().enumerate() {
-                    if i > 0 {
-                        write!(f, "; ")?;
-                    }
-                    write!(f, "{err}")?;
-                }
-                Ok(())
-            }
-            NativeRootsErrorKind::NoUsableRootsLoaded => {
-                write!(f, "no usable roots loaded from native certificate store")
-            }
-        }
+        write!(
+            f,
+            "failed to configure platform certificate verifier: {}",
+            self.0
+        )
     }
 }
 
 #[cfg(feature = "native-roots")]
 impl std::error::Error for NativeRootsError {}
 
-/// Returns a rustls ClientConfig that uses root certificates from the
-/// `rustls-native-certs` crate.
+/// Returns a rustls ClientConfig that uses certificate verification provided by
+/// the current platform.
 ///
-/// Returns an error if no usable certificates could be loaded into the root
-/// store. This can happen due to file permission issues, missing certificate
-/// stores, or certificates that rustls rejects.
+/// On platforms with a native verifier, this uses the operating system's
+/// certificate verification facilities. On other platforms, the
+/// `rustls-platform-verifier` crate falls back to the best available WebPKI
+/// verifier for that target.
+///
+/// Requires the `platform-verifier` feature to be enabled.
+#[cfg(feature = "platform-verifier")]
+#[cfg_attr(docsrs, doc(cfg(feature = "platform-verifier")))]
+pub fn config_platform_verifier() -> Result<ClientConfig, TlsError> {
+    use rustls_platform_verifier::BuilderVerifierExt as _;
+
+    Ok(ClientConfig::builder()
+        .with_platform_verifier()?
+        .with_no_client_auth())
+}
+
+/// Returns a rustls ClientConfig that uses certificate verification provided by
+/// the current platform.
 ///
 /// Requires the `native-roots` feature to be enabled.
+#[deprecated(note = "use config_platform_verifier() with the platform-verifier feature instead")]
 #[cfg(feature = "native-roots")]
 #[cfg_attr(docsrs, doc(cfg(feature = "native-roots")))]
 pub fn config_native_roots() -> Result<ClientConfig, NativeRootsError> {
-    let results = rustls_native_certs::load_native_certs();
-    config_native_roots_from_parts(results.certs, results.errors)
-}
-
-#[cfg(feature = "native-roots")]
-fn config_native_roots_from_parts(
-    certs: Vec<rustls::pki_types::CertificateDer<'static>>,
-    errors: Vec<rustls_native_certs::Error>,
-) -> Result<ClientConfig, NativeRootsError> {
-    let mut root_store = rustls::RootCertStore::empty();
-
-    if certs.is_empty() && !errors.is_empty() {
-        return Err(NativeRootsError::load(errors));
-    }
-
-    let mut added_roots = 0;
-    for cert in certs {
-        if root_store.add(cert).is_ok() {
-            added_roots += 1;
-        }
-    }
-
-    if added_roots == 0 {
-        return Err(NativeRootsError::no_usable_roots_loaded());
-    }
-
-    Ok(ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth())
+    config_platform_verifier().map_err(NativeRootsError)
 }
 
 /// Returns a rustls ClientConfig that uses root certificates from the
@@ -125,7 +80,7 @@ pub fn config_webpki_roots() -> ClientConfig {
 ///
 /// Use this only for local development, tests, or tightly controlled
 /// environments where server identity is verified by another trusted mechanism.
-/// Prefer `config_native_roots`, `config_webpki_roots`, or a custom
+/// Prefer `config_platform_verifier`, `config_webpki_roots`, or a custom
 /// [`ClientConfig`] with an explicit root store for production systems.
 pub fn config_no_verify() -> ClientConfig {
     ClientConfig::builder()
@@ -183,72 +138,4 @@ impl ServerCertVerifier for NoopTlsVerifier {
         ];
         SCHEMES.to_vec()
     }
-}
-
-#[cfg(test)]
-#[cfg(feature = "native-roots")]
-mod tests {
-    use rustls::pki_types::CertificateDer;
-
-    use super::*;
-
-    #[test]
-    fn config_native_roots_errors_when_no_roots_are_available() {
-        let err = match config_native_roots_from_parts(Vec::new(), Vec::new()) {
-            Ok(_) => panic!("empty native root result should fail"),
-            Err(err) => err,
-        };
-
-        assert_eq!(
-            err.to_string(),
-            "no usable roots loaded from native certificate store"
-        );
-    }
-
-    #[test]
-    fn config_native_roots_errors_when_all_roots_are_rejected() {
-        let invalid_cert = CertificateDer::from(vec![0]);
-        let err = match config_native_roots_from_parts(vec![invalid_cert], Vec::new()) {
-            Ok(_) => panic!("native roots rejected by rustls should fail"),
-            Err(err) => err,
-        };
-
-        assert_eq!(
-            err.to_string(),
-            "no usable roots loaded from native certificate store"
-        );
-    }
-
-    #[test]
-    fn config_native_roots_succeeds_when_at_least_one_root_is_added() {
-        install_test_crypto_provider();
-
-        let valid_cert = self_signed_cert_der();
-        let invalid_cert = CertificateDer::from(vec![0]);
-
-        assert!(config_native_roots_from_parts(vec![invalid_cert, valid_cert], Vec::new()).is_ok());
-    }
-
-    fn self_signed_cert_der() -> CertificateDer<'static> {
-        let key_pair = rcgen::KeyPair::generate().unwrap();
-        let params = rcgen::CertificateParams::new(vec!["localhost".into()]).unwrap();
-        let cert = params.self_signed(&key_pair).unwrap();
-
-        CertificateDer::from(cert.der().to_vec())
-    }
-
-    #[cfg(all(feature = "aws-lc-rs", feature = "ring"))]
-    fn install_test_crypto_provider() {
-        use std::sync::Once;
-
-        static INSTALL_PROVIDER: Once = Once::new();
-        INSTALL_PROVIDER.call_once(|| {
-            rustls::crypto::aws_lc_rs::default_provider()
-                .install_default()
-                .expect("failed to install rustls crypto provider for tests");
-        });
-    }
-
-    #[cfg(not(all(feature = "aws-lc-rs", feature = "ring")))]
-    fn install_test_crypto_provider() {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,24 +6,24 @@
 //! # Usage
 //!
 //! Prefer a verifying TLS configuration for normal application code. This crate
-//! provides helpers for the OS-native trust store and the Mozilla WebPKI trust
-//! store behind optional features.
+//! provides helpers for the platform verifier and the Mozilla WebPKI trust store
+//! behind optional features.
 //!
-//! ## Native roots
+//! ## Platform verifier
 //!
-//! Enable the `native-roots` feature to use the operating system's native
-//! certificate store.
+//! Enable the `platform-verifier` feature to use certificate verification
+//! provided by the current platform.
 //!
 //! ```rust,no_run
-//! # #[cfg(feature = "native-roots")]
+//! # #[cfg(feature = "platform-verifier")]
 //! # {
-//! use rustls_tokio_postgres::{config_native_roots, MakeRustlsConnect};
+//! use rustls_tokio_postgres::{config_platform_verifier, MakeRustlsConnect};
 //! use tokio_postgres::connect;
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! static CONFIG: &str = "host=localhost user=postgres";
 //!
-//! let tls = MakeRustlsConnect::new(config_native_roots()?);
+//! let tls = MakeRustlsConnect::new(config_platform_verifier()?);
 //!
 //! let (_client, _conn) = connect(CONFIG, tls).await?;
 //!
@@ -64,7 +64,7 @@
 //!
 //! Use this only for local development, tests, or tightly controlled
 //! environments where server identity is verified by another trusted mechanism.
-//! Prefer `config_native_roots()`, `config_webpki_roots()`, or a custom
+//! Prefer `config_platform_verifier()`, `config_webpki_roots()`, or a custom
 //! [`rustls::ClientConfig`] with an explicit root store for production systems.
 //!
 //! ```rust,no_run
@@ -89,7 +89,8 @@
 //! - **channel-binding**: enables TLS channel binding, if supported.
 //! - **fips**: enables rustls' AWS-LC-RS FIPS provider support.
 //! - **logging**: enables rustls logging. Enabled by default.
-//! - **native-roots**: enables a helper function for creating a [`rustls::ClientConfig`] using the native roots of your OS.
+//! - **native-roots**: deprecated alias for **platform-verifier**.
+//! - **platform-verifier**: enables a helper function for creating a [`rustls::ClientConfig`] using the platform certificate verifier.
 //! - **prefer-post-quantum**: enables rustls' post-quantum-preferred AWS-LC-RS key exchange ordering. Enabled by default.
 //! - **ring**: enables rustls' ring crypto provider. Use `default-features = false` if you want ring without AWS-LC-RS.
 //! - **tls12**: enables rustls TLS 1.2 support. Enabled by default.
@@ -108,9 +109,12 @@ mod config;
 mod connect;
 
 pub use config::config_no_verify;
+#[cfg(feature = "platform-verifier")]
+pub use config::config_platform_verifier;
 #[cfg(feature = "webpki-roots")]
 pub use config::config_webpki_roots;
 #[cfg(feature = "native-roots")]
+#[allow(deprecated)]
 pub use config::{NativeRootsError, config_native_roots};
 pub use rustls;
 pub use tokio_postgres;


### PR DESCRIPTION
## Summary
- Add a `platform-verifier` feature backed by `rustls-platform-verifier`.
- Keep `webpki-roots` as the static trust-store option.
- Leave `native-roots` as a deprecated compatibility alias that forwards to the platform verifier.
- Update the public docs and README to recommend the platform verifier first.

## Testing
- `cargo test`
- `cargo test --all-features`