### PR TITLE
Add CA certificate file helper for rustls config

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ A [`tokio_postgres`](https://crates.io/crates/tokio-postgres) TLS connector back
 ## Usage
 
 Prefer a verifying TLS configuration for normal application code. This crate
-provides helpers for the platform verifier and the Mozilla WebPKI trust store
-behind optional features.
+provides helpers for explicit CA certificate files, the platform verifier, and
+the Mozilla WebPKI trust store behind optional features.
 
 ### Platform verifier
 
@@ -54,6 +54,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### CA certificate
+
+Use `config_from_ca_cert()` when a provider publishes a CA certificate file or
+bundle for verifying its database servers.
+
+```rust
+use rustls_tokio_postgres::{config_from_ca_cert, MakeRustlsConnect};
+use tokio_postgres::connect;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    static CONFIG: &str = "host=localhost user=postgres";
+
+    let tls = MakeRustlsConnect::new(config_from_ca_cert("ca.pem")?);
+
+    let (_client, _conn) = connect(CONFIG, tls).await?;
+
+    Ok(())
+}
+```
+
 ### Dangerous fallback: no certificate verification
 
 `config_no_verify()` is dangerous because it disables server certificate and
@@ -63,8 +84,9 @@ man-in-the-middle attacks possible.
 
 Use this only for local development, tests, or tightly controlled environments
 where server identity is verified by another trusted mechanism. Prefer
-`config_platform_verifier()`, `config_webpki_roots()`, or a custom
-`rustls::ClientConfig` with an explicit root store for production systems.
+`config_from_ca_cert()`, `config_platform_verifier()`, `config_webpki_roots()`,
+or a custom `rustls::ClientConfig` with an explicit root store for production
+systems.
 
 ```rust
 use rustls_tokio_postgres::{config_no_verify, MakeRustlsConnect};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,59 @@
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 use rustls::{
     ClientConfig, Error as TlsError, SignatureScheme,
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    pki_types::{
+        CertificateDer,
+        pem::{Error as PemError, PemObject},
+    },
 };
+
+/// An error returned when creating a [`ClientConfig`] from a CA certificate file.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum CaCertError {
+    /// The CA certificate file could not be read or parsed as PEM.
+    Pem(PemError),
+    /// The file did not contain any PEM certificates.
+    NoCertificates,
+    /// A certificate could not be added to the root store.
+    Tls(TlsError),
+}
+
+impl std::fmt::Display for CaCertError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pem(err) => write!(f, "failed to read CA certificate file: {err}"),
+            Self::NoCertificates => {
+                write!(f, "CA certificate file did not contain any certificates")
+            }
+            Self::Tls(err) => write!(f, "failed to configure CA certificate: {err}"),
+        }
+    }
+}
+
+impl std::error::Error for CaCertError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Pem(err) => Some(err),
+            Self::NoCertificates => None,
+            Self::Tls(err) => Some(err),
+        }
+    }
+}
+
+impl From<PemError> for CaCertError {
+    fn from(err: PemError) -> Self {
+        Self::Pem(err)
+    }
+}
+
+impl From<TlsError> for CaCertError {
+    fn from(err: TlsError) -> Self {
+        Self::Tls(err)
+    }
+}
 
 /// An error returned by the deprecated `config_native_roots` helper.
 #[cfg(feature = "native-roots")]
@@ -69,6 +119,30 @@ pub fn config_webpki_roots() -> ClientConfig {
         .with_no_client_auth()
 }
 
+/// Returns a rustls ClientConfig that trusts CA certificates from a PEM file.
+///
+/// This is useful for services such as cloud database providers that publish a
+/// CA certificate or bundle for verifying their database servers. Hostname
+/// verification is still enabled; the certificates are used only as trust
+/// anchors.
+pub fn config_from_ca_cert(path: impl AsRef<Path>) -> Result<ClientConfig, CaCertError> {
+    let mut root_store = rustls::RootCertStore::empty();
+    let mut count = 0;
+
+    for ca_cert in CertificateDer::pem_file_iter(path)? {
+        root_store.add(ca_cert?)?;
+        count += 1;
+    }
+
+    if count == 0 {
+        return Err(CaCertError::NoCertificates);
+    }
+
+    Ok(ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth())
+}
+
 /// Returns a rustls ClientConfig that does not verify the server certificate.
 ///
 /// # Dangerous
@@ -80,8 +154,9 @@ pub fn config_webpki_roots() -> ClientConfig {
 ///
 /// Use this only for local development, tests, or tightly controlled
 /// environments where server identity is verified by another trusted mechanism.
-/// Prefer `config_platform_verifier`, `config_webpki_roots`, or a custom
-/// [`ClientConfig`] with an explicit root store for production systems.
+/// Prefer `config_from_ca_cert`, `config_platform_verifier`,
+/// `config_webpki_roots`, or a custom [`ClientConfig`] with an explicit root
+/// store for production systems.
 pub fn config_no_verify() -> ClientConfig {
     ClientConfig::builder()
         .dangerous()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //! # Usage
 //!
 //! Prefer a verifying TLS configuration for normal application code. This crate
-//! provides helpers for the platform verifier and the Mozilla WebPKI trust store
-//! behind optional features.
+//! provides helpers for explicit CA certificate files, the platform verifier,
+//! and the Mozilla WebPKI trust store behind optional features.
 //!
 //! ## Platform verifier
 //!
@@ -55,6 +55,26 @@
 //! # }
 //! ```
 //!
+//! ## CA certificate
+//!
+//! Use [`config_from_ca_cert()`] when a provider publishes a CA certificate file
+//! or bundle for verifying its database servers.
+//!
+//! ```rust,no_run
+//! use rustls_tokio_postgres::{config_from_ca_cert, MakeRustlsConnect};
+//! use tokio_postgres::connect;
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! static CONFIG: &str = "host=localhost user=postgres";
+//!
+//! let tls = MakeRustlsConnect::new(config_from_ca_cert("ca.pem")?);
+//!
+//! let (_client, _conn) = connect(CONFIG, tls).await?;
+//!
+//! Ok(())
+//! # }
+//! ```
+//!
 //! ## Dangerous fallback: no certificate verification
 //!
 //! [`config_no_verify()`] is dangerous because it disables server certificate
@@ -64,8 +84,9 @@
 //!
 //! Use this only for local development, tests, or tightly controlled
 //! environments where server identity is verified by another trusted mechanism.
-//! Prefer `config_platform_verifier()`, `config_webpki_roots()`, or a custom
-//! [`rustls::ClientConfig`] with an explicit root store for production systems.
+//! Prefer `config_from_ca_cert()`, `config_platform_verifier()`,
+//! `config_webpki_roots()`, or a custom [`rustls::ClientConfig`] with an
+//! explicit root store for production systems.
 //!
 //! ```rust,no_run
 //! use rustls_tokio_postgres::{config_no_verify, MakeRustlsConnect};
@@ -113,6 +134,7 @@ pub use config::config_no_verify;
 pub use config::config_platform_verifier;
 #[cfg(feature = "webpki-roots")]
 pub use config::config_webpki_roots;
+pub use config::{CaCertError, config_from_ca_cert};
 #[cfg(feature = "native-roots")]
 #[allow(deprecated)]
 pub use config::{NativeRootsError, config_native_roots};

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use rustls_tokio_postgres::MakeRustlsConnect;
 use rustls_tokio_postgres::rustls::ClientConfig;
@@ -28,13 +29,23 @@ fn test_tls_configs() -> (rustls::ServerConfig, ClientConfig) {
         .with_single_cert(vec![cert_der.clone()], key_der)
         .unwrap();
 
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.add(cert_der).unwrap();
-    let client_config = ClientConfig::builder()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+    let ca_cert_path = write_temp_ca_file(cert.pem());
+    let client_config = rustls_tokio_postgres::config_from_ca_cert(&ca_cert_path).unwrap();
+    std::fs::remove_file(ca_cert_path).unwrap();
 
     (server_config, client_config)
+}
+
+fn write_temp_ca_file(contents: impl AsRef<[u8]>) -> std::path::PathBuf {
+    static NEXT_CA_FILE: AtomicUsize = AtomicUsize::new(0);
+
+    let path = std::env::temp_dir().join(format!(
+        "rustls-tokio-postgres-ca-{}-{}.pem",
+        std::process::id(),
+        NEXT_CA_FILE.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&path, contents).unwrap();
+    path
 }
 
 fn config_no_verify() -> ClientConfig {
@@ -156,13 +167,21 @@ fn make_tls_connect_ipv6_succeeds() {
 }
 
 // ---------------------------------------------------------------------------
-// config_no_verify – smoke test
+// Config helpers – smoke tests
 // ---------------------------------------------------------------------------
 
 #[test]
 fn config_no_verify_returns_usable_config() {
     let config = config_no_verify();
     let _ = MakeRustlsConnect::new(config);
+}
+
+#[test]
+fn config_from_ca_cert_rejects_invalid_cert_file() {
+    let ca_cert_path = write_temp_ca_file("not a certificate");
+
+    assert!(rustls_tokio_postgres::config_from_ca_cert(&ca_cert_path).is_err());
+    std::fs::remove_file(ca_cert_path).unwrap();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `config_from_ca_cert(path)` to load PEM CA certificates from a file and build a `rustls::ClientConfig`.
- Export a new `CaCertError` for PEM parsing, empty-file, and rustls configuration failures.
- Update docs and examples to show the file-based CA workflow used by cloud DB providers.
- Add tests that exercise the helper with a generated PEM file and an invalid file.

## Testing
- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`