### PR TITLE
Enable channel-binding by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,13 @@ keywords = ["tokio-postgres", "rustls", "postgres", "sql"]
 categories = ["database"]
 
 [features]
-default = ["aws-lc-rs", "logging", "prefer-post-quantum", "tls12"]
+default = [
+    "aws-lc-rs",
+    "channel-binding",
+    "logging",
+    "prefer-post-quantum",
+    "tls12",
+]
 aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 channel-binding = ["dep:sha2", "dep:x509-parser"]
 fips = ["aws-lc-rs", "rustls/fips", "tokio-rustls/fips"]

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ## Features
 
 - **aws-lc-rs**: enables rustls' AWS-LC-RS crypto provider. Enabled by default.
-- **channel-binding**: enables TLS channel binding, if supported.
+- **channel-binding**: enables TLS channel binding, if supported. Enabled by default.
 - **fips**: enables rustls' AWS-LC-RS FIPS provider support.
 - **logging**: enables rustls logging. Enabled by default.
 - **native-roots**: deprecated alias for **platform-verifier**.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@
 //! # Features
 //!
 //! - **aws-lc-rs**: enables rustls' AWS-LC-RS crypto provider. Enabled by default.
-//! - **channel-binding**: enables TLS channel binding, if supported.
+//! - **channel-binding**: enables TLS channel binding, if supported. Enabled by default.
 //! - **fips**: enables rustls' AWS-LC-RS FIPS provider support.
 //! - **logging**: enables rustls logging. Enabled by default.
 //! - **native-roots**: deprecated alias for **platform-verifier**.


### PR DESCRIPTION
## Summary
- Add `channel-binding` to the crate's default feature set
- Update README and crate docs to note that it is enabled by default

## Testing
- Not run (not requested)