### PR TITLE
Update TLS examples to require SSL and spawn connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,16 @@ use tokio_postgres::connect;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    static CONFIG: &str = "host=localhost user=postgres";
+    static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 
     let tls = MakeRustlsConnect::new(config_platform_verifier()?);
 
-    let (_client, _conn) = connect(CONFIG, tls).await?;
+    let (client, connection) = connect(CONFIG, tls).await?;
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            eprintln!("postgres connection error: {err}");
+        }
+    });
 
     Ok(())
 }
@@ -54,11 +59,16 @@ use tokio_postgres::connect;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    static CONFIG: &str = "host=localhost user=postgres";
+    static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 
     let tls = MakeRustlsConnect::new(config_webpki_roots());
 
-    let (_client, _conn) = connect(CONFIG, tls).await?;
+    let (client, connection) = connect(CONFIG, tls).await?;
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            eprintln!("postgres connection error: {err}");
+        }
+    });
 
     Ok(())
 }
@@ -75,11 +85,16 @@ use tokio_postgres::connect;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    static CONFIG: &str = "host=localhost user=postgres";
+    static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 
     let tls = MakeRustlsConnect::new(config_from_ca_cert("ca.pem")?);
 
-    let (_client, _conn) = connect(CONFIG, tls).await?;
+    let (client, connection) = connect(CONFIG, tls).await?;
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            eprintln!("postgres connection error: {err}");
+        }
+    });
 
     Ok(())
 }
@@ -104,11 +119,16 @@ use tokio_postgres::connect;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    static CONFIG: &str = "host=localhost user=postgres";
+    static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 
     let tls = MakeRustlsConnect::new(config_no_verify());
 
-    let (_client, _conn) = connect(CONFIG, tls).await?;
+    let (client, connection) = connect(CONFIG, tls).await?;
+    tokio::spawn(async move {
+        if let Err(err) = connection.await {
+            eprintln!("postgres connection error: {err}");
+        }
+    });
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,16 @@
 //! use tokio_postgres::connect;
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-//! static CONFIG: &str = "host=localhost user=postgres";
+//! static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 //!
 //! let tls = MakeRustlsConnect::new(config_platform_verifier()?);
 //!
-//! let (_client, _conn) = connect(CONFIG, tls).await?;
+//! let (client, connection) = connect(CONFIG, tls).await?;
+//! tokio::spawn(async move {
+//!     if let Err(err) = connection.await {
+//!         eprintln!("postgres connection error: {err}");
+//!     }
+//! });
 //!
 //! Ok(())
 //! # }
@@ -55,11 +60,16 @@
 //! use tokio_postgres::connect;
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-//! static CONFIG: &str = "host=localhost user=postgres";
+//! static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 //!
 //! let tls = MakeRustlsConnect::new(config_webpki_roots());
 //!
-//! let (_client, _conn) = connect(CONFIG, tls).await?;
+//! let (client, connection) = connect(CONFIG, tls).await?;
+//! tokio::spawn(async move {
+//!     if let Err(err) = connection.await {
+//!         eprintln!("postgres connection error: {err}");
+//!     }
+//! });
 //!
 //! Ok(())
 //! # }
@@ -76,11 +86,16 @@
 //! use tokio_postgres::connect;
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-//! static CONFIG: &str = "host=localhost user=postgres";
+//! static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 //!
 //! let tls = MakeRustlsConnect::new(config_from_ca_cert("ca.pem")?);
 //!
-//! let (_client, _conn) = connect(CONFIG, tls).await?;
+//! let (client, connection) = connect(CONFIG, tls).await?;
+//! tokio::spawn(async move {
+//!     if let Err(err) = connection.await {
+//!         eprintln!("postgres connection error: {err}");
+//!     }
+//! });
 //!
 //! Ok(())
 //! # }
@@ -104,12 +119,17 @@
 //! use tokio_postgres::connect;
 //!
 //! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
-//! static CONFIG: &str = "host=localhost user=postgres";
+//! static CONFIG: &str = "host=localhost user=postgres sslmode=require";
 //!
 //! let config = config_no_verify();
 //!
 //! let tls = MakeRustlsConnect::new(config);
-//! let (_client, _conn) = connect(CONFIG, tls).await?;
+//! let (client, connection) = connect(CONFIG, tls).await?;
+//! tokio::spawn(async move {
+//!     if let Err(err) = connection.await {
+//!         eprintln!("postgres connection error: {err}");
+//!     }
+//! });
 //!
 //! Ok(())
 //! # }


### PR DESCRIPTION
## Summary
- Require `sslmode=require` in the TLS usage examples
- Show spawning the returned connection task so the client remains usable
- Apply the same fixes in `README.md` and crate docs

## Testing
- Not run (not requested)