### PR TITLE
Exclude repository metadata from the published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/ryanfowler/rustls-tokio-postgres"
 license = "Apache-2.0"
 keywords = ["tokio-postgres", "rustls", "postgres", "sql"]
 categories = ["database"]
+exclude = [".github", "Cargo.lock"]
 
 [features]
 default = [


### PR DESCRIPTION
## Summary
- Exclude `.github` and `Cargo.lock` from the published package
- Reduce crate packaging noise without affecting source code

## Testing
- Not run (not requested)