### PR TITLE
refactor: simplify TLS connect future polling

### DIFF
--- a/src/connect.rs
+++ b/src/connect.rs
@@ -49,11 +49,7 @@ where
     type Output = io::Result<TlsStream<S>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match Pin::new(&mut self.inner).poll(cx) {
-            Poll::Ready(Ok(stream)) => Poll::Ready(Ok(TlsStream(stream))),
-            Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
-            Poll::Pending => Poll::Pending,
-        }
+        Pin::new(&mut self.inner).poll(cx).map(|r| r.map(TlsStream))
     }
 }
 


### PR DESCRIPTION
## Summary
- Simplify RustlsConnectFuture::poll using Poll::map and Result::map

## Validation
- cargo test